### PR TITLE
Print trailing quote for variable summary

### DIFF
--- a/Hl7.Fhir.MappingLanguage/JavaStructureMapUtils-Analyze.cs
+++ b/Hl7.Fhir.MappingLanguage/JavaStructureMapUtils-Analyze.cs
@@ -262,7 +262,7 @@ namespace Hl7.Fhir.MappingLanguage
                 if (ModelInfo.IsPrimitive(_object.InstanceType))
                     return _name + ": \"" + _object.Value?.ToString() + '"';
                 if (ModelInfo.IsKnownResource(_object.InstanceType))
-                    return _name + ": \"" + _object.Value?.DebuggerDisplayString() ?? _object.Value?.GetHashCode().ToString() + '"';
+                    return _name + ": \"" + (_object.Value?.DebuggerDisplayString() ?? _object.Value?.GetHashCode().ToString()) + '"';
                 return _name + ": (" + _object.InstanceType + ")";
             }
         }


### PR DESCRIPTION
Before - `debug: Group : Bundle; vars = source variables [src: "], target variables [tgt: "], shared variables []`

After - `debug: Group : Bundle; vars = source variables [src: ""], target variables [tgt: ""], shared variables []`

Somehow the last bit of code wasn't even being executed!